### PR TITLE
ECONNRESET Watcher

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -154,4 +154,9 @@ process.on("exit", () => {
 
 process.on("unhandledRejection", (err) => {
   helpers.log("Promise Rejection: " + err);
+  // watch for ECONNRESET
+  if (err.code === "ECONNRESET") {
+    helpers.log("Connection Lost, Signalling restart");
+    process.exit();
+  }
 });


### PR DESCRIPTION
## Issue: discord and Niles lose connection but no error or event thrown
## Conditions to meet: 
- [x] Bot shows up as offline
- [x] process does not crash/ PM2 shows process as running
- [x] bot does not respond to any commands

## Recreation:
1. Shape traffic to 1B/s upload and download each using whatever means necessary
2. Kill connections from node (tcpkill or NetLimiter)
3. Watch the bot spew errors with code `ECONNRESET`
4. (Optional) Remove traffic shaping

## Rationale:
Assuming this is the issue that can trigger the disconnects without notifying PM2 or spawning any errors, ( see error at [gist](https://gist.github.com/mchangrh/5c461c2def4e59ae3fec341e45d322b4) ), the following code watches for `unhandledRejections` with the code `ECONNRESET` and signals the process to exit discord and then signal PM2 to restart the process with SIGINT