### PR TITLE
24 hour format

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -47,7 +47,7 @@ Visit the [setup page](http://niles.seanecoffey.com/setup) for more detailed set
 
 * `!displayoptions help`    - Turn off the help text under the calendar, takes 1 or 0 as input (on or off) i.e. `!displayoptions help 0` to turn off help text.
 * `!displayoptions pin`     - Turn off pinning of the calendar, takes 1 or 0 as input (on or off) i.e. `!displayoptions pin 0` to turn off pinning.
-* `!displayoptions format`  - Change clock format between 12 and 24-hour format, takes 12 or 24 as input i.e. `displayopions format 24` to disply events in 24-hour clock format.
+* `!displayoptions format`  - Change clock format between 12 and 24-hour clock format, takes 12 or 24 as input i.e. `displayopions format 24` to disply events in 24-hour clock format.
 
 ## Support
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,8 +45,9 @@ Visit the [setup page](http://niles.seanecoffey.com/setup) for more detailed set
 
 ### Display Options
 
-* `!displayoptions help` - Turn off the help text under the calendar, takes 1 or 0 as input (on or off) i.e. `!displayoptions help 0` to turn off help text.
-* `!displayoptions pin`  - Turn off pinning of the calendar, takes 1 or 0 as input (on or off) i.e. `!displayoptions pin 0` to turn off pinning.
+* `!displayoptions help`    - Turn off the help text under the calendar, takes 1 or 0 as input (on or off) i.e. `!displayoptions help 0` to turn off help text.
+* `!displayoptions pin`     - Turn off pinning of the calendar, takes 1 or 0 as input (on or off) i.e. `!displayoptions pin 0` to turn off pinning.
+* `!displayoptions format`  - Change clock format between 12 and 24-hour format, takes 12 or 24 as input i.e. `displayopions format 24` to disply events in 24-hour clock format.
 
 ## Support
 

--- a/handlers/commands.js
+++ b/handlers/commands.js
@@ -139,7 +139,6 @@ function getEvents(message, calendarID, dayMap) {
     let tz = guildSettings.timezone;
     let startDate = helpers.stringDate(dayMap[0], message.guild.id, "start");
     let endDate = helpers.stringDate(dayMap[6], message.guild.id, "end");
-    let format = guildSettings.format;
     let params = {
       timeMin: startDate,
       timeMax: endDate,

--- a/handlers/commands.js
+++ b/handlers/commands.js
@@ -512,6 +512,18 @@ function displayOptions(message) {
     } else {
       message.channel.send("Please only use 0 or 1 for the calendar help menu options, (off or on)");
     }
+  } else if (pieces[1] === "format") {
+    if (pieces[2] === "12") {
+      guildSettings.format = 12;
+      helpers.writeGuildSpecific(message.guild.id, guildSettings, "settings");
+      message.channel.send("Set to 12-Hour clock format");
+    } else if (pieces[2] === "24") {
+      guildSettings.format = 24;
+      helpers.writeGuildSpecific(message.guild.id, guildSettings, "settings");
+      message.channel.send("Set to 24-Hour clock format");
+    } else {
+      message.channel.send("Please only use 12 or 24 for the clock display options");
+    }
   } else if (pieces[1] == null) {
     message.channel.send("`!displayoptions help` and `!displayoptions pin` are the only valid Display Options.");
   }

--- a/handlers/commands.js
+++ b/handlers/commands.js
@@ -525,7 +525,7 @@ function displayOptions(message) {
       message.channel.send("Please only use 12 or 24 for the clock display options");
     }
   } else if (pieces[1] == null) {
-    message.channel.send("`!displayoptions help` and `!displayoptions pin` are the only valid Display Options.");
+    message.channel.send("`!displayoptions help`, `!displayoptions pin` and `!displayoptions format` are the only valid Display Options.");
   }
   else {
     message.channel.send("I don't think thats a valid display option, sorry!");

--- a/handlers/commands.js
+++ b/handlers/commands.js
@@ -139,6 +139,7 @@ function getEvents(message, calendarID, dayMap) {
     let tz = guildSettings.timezone;
     let startDate = helpers.stringDate(dayMap[0], message.guild.id, "start");
     let endDate = helpers.stringDate(dayMap[6], message.guild.id, "end");
+    let format = guildSettings.format;
     let params = {
       timeMin: startDate,
       timeMax: endDate,
@@ -236,6 +237,7 @@ function generateCalendar(message, dayMap) {
   let calendar = helpers.readFile(calendarPath);
   let guildSettingsPath = path.join(__dirname, "..", "stores", message.guild.id, "settings.json");
   let guildSettings = helpers.readFile(guildSettingsPath);
+  let format = guildSettings.format;
   let p = defer();
   let finalString = "";
   for (let i = 0; i < 7; i++) {
@@ -276,7 +278,7 @@ function generateCalendar(message, dayMap) {
           tempStartDate = helpers.convertDate(tempStartDate, message.guild.id);
           let tempFinDate = new Date(calendar[key][m].end.dateTime);
           tempFinDate = helpers.convertDate(tempFinDate, message.guild.id);
-          tempString[helpers.getStringTime(tempStartDate) + " - " + helpers.getStringTime(tempFinDate)] = calendar[key][m].summary;
+          tempString[helpers.getStringTime(tempStartDate,format) + " - " + helpers.getStringTime(tempFinDate,format)] = calendar[key][m].summary;
           sendString += columnify(tempString, options) + "\n";
         }
       }

--- a/handlers/guilds.js
+++ b/handlers/guilds.js
@@ -28,6 +28,7 @@ exports.create = (guild) => {
     "calendarChannel": "",
     "timezone": "",
     "helpmenu": "1",
+    "format": 12,
     "allowedRoles": []
   };
   const guildData = {

--- a/handlers/helpers.js
+++ b/handlers/helpers.js
@@ -228,22 +228,31 @@ function stringDate(date, guildid, hour) {
   return dateString;
 }
 
-function getStringTime(date) {
+function getStringTime(date, format) {
+  // check for 24 hour switch
   let hour = date.getHours();
   let minutes = prependZero(date.getMinutes());
-  if (minutes === "00") {
-    if (hour <= 11) {
-      return hourString(parseInt(date.getHours(), 10)) + "AM";
-    }
-    if (hour > 11) {
-      return hourString(parseInt(date.getHours(), 10)) + "PM";
-    }
-  } else {
-    if (hour <= 11) {
-      return `${hourString(parseInt(date.getHours(),10))}:${minutes}AM`;
-    }
-    if (hour > 11) {
-      return `${hourString(parseInt(date.getHours(),10))}:${minutes}PM`;
+  // 24 hour format
+  if (format === 24) {
+    // just return hour format
+    return `${hour}:${minutes}`;
+  }
+  // 12 hour format
+  else {
+    if (minutes === "00") {
+      if (hour <= 11) {
+        return hourString(parseInt(date.getHours(), 10)) + "AM";
+      }
+      if (hour > 11) {
+        return hourString(parseInt(date.getHours(), 10)) + "PM";
+      }
+    } else {
+      if (hour <= 11) {
+        return `${hourString(parseInt(date.getHours(),10))}:${minutes}AM`;
+      }
+      if (hour > 11) {
+        return `${hourString(parseInt(date.getHours(),10))}:${minutes}PM`;
+      }
     }
   }
 }

--- a/handlers/helpers.js
+++ b/handlers/helpers.js
@@ -234,8 +234,8 @@ function getStringTime(date, format) {
   let minutes = prependZero(date.getMinutes());
   // 24 hour format
   if (format === 24) {
-    // just return hour format
-    return `${hour}:${minutes}`;
+    // just return hour format with prepended zero
+    return `${prependZero(hour)}:${minutes}`;
   }
   // 12 hour format
   else {


### PR DESCRIPTION
addressing #30 

- set using `!displayoptions format`
- 12AM displayed as 00:00
- Minutes always appended (00 minutes are kept)
- AM times prepended with zero
- backwards compatible, defaults to previous 12-hour formatting

Checks
- [x] Added to documentation/ help
- [x] Handles error inputs
- [x] New guilds defaulted to 12-hour
- [x] Old guilds can define new format seamlessly