### PR TITLE
fixes #46

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -140,6 +140,7 @@ client.on("message", (message) => {
 // ProcessListeners
 process.on("uncaughtException", (err) => {
   helpers.log("uncaughtException error" + err);
+  process.exit();
 });
 
 process.on("SIGINT", () => {

--- a/handlers/helpers.js
+++ b/handlers/helpers.js
@@ -41,7 +41,9 @@ function readFile(path) {
   try {
     return JSON.parse(fs.readFileSync(path, "utf8"));
   } catch (err) {
-    return log("error reading file " + err);
+    log("error reading file " + err);
+    // return valid JSON to trigger update
+    return {};
   }
 }
 


### PR DESCRIPTION
gracefully handles unavailable files, properly exists on `uncaughtException` errors

with some help from [StackOverflow](https://stackoverflow.com/a/62590868) - file read errors are properly handled and will trigger a database update rather than soft crashing the process. Instead of returning a `log()` or `null` object and triggering an `uncaughtException`, an empty json object is returned, that will prompt less severe errors

Previous soft crashes from `uncaughtException` errors now hard crash and will signal a restart for supervisor