### PR TITLE
Fix Issues in collecting and displaying multi-day events + additional displayoptions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -49,6 +49,8 @@ Visit the [setup page](http://niles.seanecoffey.com/setup) for more detailed set
 * `!displayoptions pin`       - Turn off pinning of the calendar, takes 1 or 0 as input (on or off) i.e. `!displayoptions pin 0` to turn off pinning.
 * `!displayoptions format`    - Change clock format between 12 and 24-hour clock format, takes 12 or 24 as input i.e. `displayoptions format 24` to disply events in 24-hour clock format.
 * `!displayoptions tzdisplay` - Turn off timezone display, take 1 or 0 as input (on or off) i.e. `!displayoptions tzdisplay 0` to turn off timezone display.
+* `!displayoptions emptydays` - Hide or show empty days, takes 1 or 0 as input (show or hide) i.e. `!displayoptions emptydays 0` to hide empty days
+* `!displayoptions trim`      - Trim event names to n characters, with 0 being off. i.e. `!displayoptions trim 15` will limit event names to 5 characters and the rest being `...`
 
 ### !create formatting
 `!create` is entirely handled by Google Calendar.
@@ -82,4 +84,4 @@ Sean Coffey ([GitHub](http://github.com/seanecoffey)).
 
 [MIT License](http://seanecoffey.mit-license.org/)
 
-Last update: 8 Feb 2020
+Last update: 15 Oct 2020

--- a/handlers/commands.js
+++ b/handlers/commands.js
@@ -540,19 +540,7 @@ function displayOptions(message) {
       message.channel.send("Please provide a number to trim event titels. (0 = don't trim!)");
     }
   } else {
-    let usageMessage = `**displayoptions USAGE**\`\`\`
-    COMMAND                       PARAMS      EFFECT
-    ---------------------------------------------------------------------------
-    !displayoptions help          (0|1)       hide/show help
-    !displayoptions pin           (0|1)       pin calendar message
-    !displayoptions format        (12|24)     12h or 24h clock display 
-    !displayoptions tzdisplay     (0|1)       hide/show timezone
-    !displayoptions emptydays     (0|1)       hide/show empty days
-    !displayoptions trim          (n)         trim event names to n characters (0 = off)
-    \`\`\`
-    `;
-    let b = "`!displayoptions help`, `!displayoptions pin`, `!displayoptions format`, `!displayoptions tzdisplay` are the only valid Display Options.";
-    message.channel.send(usageMessage);
+    message.channel.send(strings.DISPLAYOPTIONS_USAGE);
   }
 }
 

--- a/handlers/commands.js
+++ b/handlers/commands.js
@@ -248,10 +248,10 @@ function generateCalendar(message, dayMap) {
           let tempFinDate = "...";
           let tempStringKey = "";
           if(calendar[key][m].type === eventType.SINGLE || calendar[key][m].type === eventType.MULTISTART) {
-            tempStartDate = helpers.getStringTime(helpers.momentDate(calendar[key][m].start.dateTime, message.guild.id));
+            tempStartDate = helpers.getStringTime(calendar[key][m].start.dateTime, message.guild.id);
           } 
           if(calendar[key][m].type === eventType.SINGLE || calendar[key][m].type === eventType.MULTYEND) {
-            tempFinDate = helpers.getStringTime(helpers.momentDate(calendar[key][m].end.dateTime, message.guild.id));
+            tempFinDate = helpers.getStringTime(calendar[key][m].end.dateTime, message.guild.id);
           }
           if(calendar[key][m].type === eventType.MULTIMID){
             tempStringKey = "All Day";

--- a/handlers/commands.js
+++ b/handlers/commands.js
@@ -213,7 +213,9 @@ function generateCalendar(message, dayMap) {
     let key = "day" + String(i);
     let sendString = "";
     sendString += "\n" + moment(dayMap[i]).format("**dddd** - MMMM D\n");
-    if(guildSettings.emptydays === "0" && calendar[key].length === 0) continue;
+    if(guildSettings.emptydays === "0" && calendar[key].length === 0) {
+      continue;
+    }
     if (calendar[key].length === 0) {
       sendString += "``` ```";
     } else {

--- a/handlers/commands.js
+++ b/handlers/commands.js
@@ -5,13 +5,6 @@ const CalendarAPI = require("@mchangrh/node-google-calendar");
 const columnify = require("columnify");
 const os = require("os");
 const moment = require("moment-timezone");
-const eventType = {
-  NOMATCH: "nm",
-  SINGLE: "se",
-  MULTISTART: "ms",
-  MULTIMID: "mm",
-  MULTYEND: "me"
-};
 require("moment-duration-format");
 const strings = require("./strings.js");
 let bot = require("../bot.js");
@@ -22,7 +15,7 @@ let guilds = require("./guilds.js");
 let cal = new CalendarAPI(settings.calendarConfig);
 let autoUpdater = [];
 let timerCount = [];
-
+let eventType = helpers.eventType;
 //functions
 
 function clean(channel, numberMessages, recurse) {
@@ -167,7 +160,7 @@ function getEvents(message, calendarID, dayMap) {
           }
 
           let eType = helpers.classifyEventMatch(dayMap[day], eStartDate, eEndDate);
-          if (eType != eventType.NOMATCH) {
+          if (eType !== eventType.NOMATCH) {
             matches.push({
               id: json[i].id,
               summary: json[i].summary,

--- a/handlers/commands.js
+++ b/handlers/commands.js
@@ -121,40 +121,6 @@ function createDayMap(message) {
   return dayMap;
 }
 
-/**
- * This function returns a classification of type 'eventType' to state the relation between a date and an event.
- * You can only check for the DAY relation, of checkDate, not the full dateTime relation!
- * @param {Date} checkDate - the Date to classify for an event
- * @param {Date} eventStartDate - the start Date() of an event
- * @param {Date} eventEndDate - the end Date() of an event
- * @return {string} eventType - A string of ENUM(eventType) representing the relation
- */
-function classifyEventMatch(checkDate, eventStartDate, eventEndDate) {
-  // remove the time to prevent call-time dependant issues
-  let lCheckDate = new Date(checkDate.getFullYear(), checkDate.getMonth(), checkDate.getDate());
-  let lEventStartDate = new Date(eventStartDate.getFullYear(), eventStartDate.getMonth(), eventStartDate.getDate());
-  let lEventEndDate = new Date(eventEndDate.getFullYear(), eventEndDate.getMonth(), eventEndDate.getDate());
-  let eventMatchType = eventType.NOMATCH;
-  // simple single day event
-  if(moment(lCheckDate).isSame(lEventStartDate) && moment(lEventStartDate).isSame(lEventEndDate)){
-    eventMatchType = eventType.SINGLE;
-}
-  // multi-day event
-  else if(!moment(lEventStartDate).isSame(lEventEndDate))
-  {
-    if(moment(lCheckDate).isSame(lEventStartDate)){
-      eventMatchType = eventType.MULTISTART;
-    }
-    else if(moment(lCheckDate).isSame(lEventEndDate)){
-      eventMatchType = eventType.MULTYEND;
-    } 
-    else if(moment(lCheckDate).isAfter(lEventStartDate) && moment(lCheckDate).isBefore(lEventEndDate)){
-      eventMatchType = eventType.MULTIMID;
-    } 
-  }
-  return eventMatchType;
-}
-
 function getEvents(message, calendarID, dayMap) {
   try {
     let tempDayArray = {
@@ -200,7 +166,7 @@ function getEvents(message, calendarID, dayMap) {
             eEndDate = new Date(new Date(json[i].end.date).getTime()-(1*24*60*60*1000));
           }
 
-          let eType = classifyEventMatch(dayMap[day], eStartDate, eEndDate);
+          let eType = helpers.classifyEventMatch(dayMap[day], eStartDate, eEndDate);
           if (eType != eventType.NOMATCH) {
             matches.push({
               id: json[i].id,

--- a/handlers/guilds.js
+++ b/handlers/guilds.js
@@ -27,7 +27,9 @@ exports.create = (guild) => {
     "helpmenu": "1",
     "format": 12,
     "tzDisplay": "0",
-    "allowedRoles": []
+    "allowedRoles": [],
+    "emptydays": "1",
+    "trim": 0
   };
   const guildData = {
     "guildid": guild.id,

--- a/handlers/helpers.js
+++ b/handlers/helpers.js
@@ -2,6 +2,13 @@ const fs = require("fs");
 const path = require("path");
 const defer = require("promise-defer");
 const moment = require("moment-timezone");
+const eventType = {
+  NOMATCH: "nm",
+  SINGLE: "se",
+  MULTISTART: "ms",
+  MULTIMID: "mm",
+  MULTYEND: "me"
+};
 let settings = require("../settings.js");
 let bot = require("../bot.js");
 let minimumPermissions = settings.secrets.minimumPermissions;
@@ -344,5 +351,6 @@ module.exports = {
   checkPermissionsManual,
   checkRole,
   yesThenCollector,
-  classifyEventMatch
+  classifyEventMatch,
+  eventType
 };

--- a/handlers/helpers.js
+++ b/handlers/helpers.js
@@ -284,6 +284,40 @@ function yesThenCollector(message) {
   return p.promise;
 }
 
+/**
+ * This function returns a classification of type 'eventType' to state the relation between a date and an event.
+ * You can only check for the DAY relation, of checkDate, not the full dateTime relation!
+ * @param {Date} checkDate - the Date to classify for an event
+ * @param {Date} eventStartDate - the start Date() of an event
+ * @param {Date} eventEndDate - the end Date() of an event
+ * @return {string} eventType - A string of ENUM(eventType) representing the relation
+ */
+function classifyEventMatch(checkDate, eventStartDate, eventEndDate) {
+  // remove the time to prevent call-time dependant issues
+  let lCheckDate = new Date(checkDate.getFullYear(), checkDate.getMonth(), checkDate.getDate());
+  let lEventStartDate = new Date(eventStartDate.getFullYear(), eventStartDate.getMonth(), eventStartDate.getDate());
+  let lEventEndDate = new Date(eventEndDate.getFullYear(), eventEndDate.getMonth(), eventEndDate.getDate());
+  let eventMatchType = eventType.NOMATCH;
+  // simple single day event
+  if(moment(lCheckDate).isSame(lEventStartDate) && moment(lEventStartDate).isSame(lEventEndDate)){
+    eventMatchType = eventType.SINGLE;
+  }
+  // multi-day event
+  else if(!moment(lEventStartDate).isSame(lEventEndDate))
+  {
+    if(moment(lCheckDate).isSame(lEventStartDate)){
+      eventMatchType = eventType.MULTISTART;
+    }
+    else if(moment(lCheckDate).isSame(lEventEndDate)){
+      eventMatchType = eventType.MULTYEND;
+    } 
+    else if(moment(lCheckDate).isAfter(lEventStartDate) && moment(lCheckDate).isBefore(lEventEndDate)){
+      eventMatchType = eventType.MULTIMID;
+    } 
+  }
+  return eventMatchType;
+}
+
 module.exports = {
   fullname,
   deleteFolderRecursive,
@@ -309,5 +343,6 @@ module.exports = {
   checkPermissions,
   checkPermissionsManual,
   checkRole,
-  yesThenCollector
+  yesThenCollector,
+  classifyEventMatch
 };

--- a/handlers/helpers.js
+++ b/handlers/helpers.js
@@ -333,7 +333,9 @@ function classifyEventMatch(checkDate, eventStartDate, eventEndDate) {
  * @return {string} eventName - A string wit max 23 chars length
  */
 function trimEventName(eventName, trimLength){
-  if(trimLength === null || trimLength === 0) return eventName;
+  if(trimLength === null || trimLength === 0){
+    return eventName;
+  }
 
   if(eventName.length > trimLength){
     eventName = eventName.trim().substring(0, trimLength-3) + "...";

--- a/handlers/helpers.js
+++ b/handlers/helpers.js
@@ -325,6 +325,23 @@ function classifyEventMatch(checkDate, eventStartDate, eventEndDate) {
   return eventMatchType;
 }
 
+
+/**
+ * This helper function limits the amount of chars in a string to max trimLength and adds "..." if shortened.
+ * @param {string} eventName - The name/summary of an event
+ * @param {int} trimLength - the number of chars to trim the title to
+ * @return {string} eventName - A string wit max 23 chars length
+ */
+function trimEventName(eventName, trimLength){
+  if(trimLength === null || trimLength === 0) return eventName;
+
+  if(eventName.length > trimLength){
+    eventName = eventName.trim().substring(0, trimLength-3) + "...";
+  }
+  return eventName;
+}
+
+
 module.exports = {
   fullname,
   deleteFolderRecursive,
@@ -352,5 +369,6 @@ module.exports = {
   checkRole,
   yesThenCollector,
   classifyEventMatch,
-  eventType
+  eventType,
+  trimEventName
 };

--- a/handlers/helpers.js
+++ b/handlers/helpers.js
@@ -209,8 +209,8 @@ function stringDate(date, guildid, hour) {
  */
 function getStringTime(date, guildid) {
   let guildSettings = getGuildSettings(guildid, "settings");
-  let format = guildSettings.format
-  let timezone = guildSettings.timezone
+  let format = guildSettings.format;
+  let timezone = guildSettings.timezone;
   // m.format(hA:mm) - 9:05AM
   // m.format(HH:mm) - 09:05
   const m = addTz(date, timezone); // no parsezone since we are passing in a moment object

--- a/handlers/helpers.js
+++ b/handlers/helpers.js
@@ -191,11 +191,6 @@ function addTz(time, timezone) {
   }
 }
 
-function momentDate(time, guildid) {
-  let guildSettings = getGuildSettings(guildid, "settings");
-  return addTz(time, guildSettings.timezone);
-}
-
 // returns date object adjusted for tz
 function convertDate(dateToConvert, guildid) {
   let guildSettings = getGuildSettings(guildid, "settings");
@@ -206,11 +201,19 @@ function stringDate(date, guildid, hour) {
   let guildSettings = getGuildSettings(guildid, "settings");
   return addTz(date, guildSettings.timezone).toISOString(true);
 }
-
-function getStringTime(date, format) {
+/**
+ * Make a nicely formatted string with timezone adjustment from date object
+ * @param {Date} date - date object to convert 
+ * @param {Snowflake} guildid - Guild ID to get settings from
+ * @return {string} - nicely formatted string for date event
+ */
+function getStringTime(date, guildid) {
+  let guildSettings = getGuildSettings(guildid, "settings");
+  let format = guildSettings.format
+  let timezone = guildSettings.timezone
   // m.format(hA:mm) - 9:05AM
   // m.format(HH:mm) - 09:05
-  const m = moment(date); // no parsezone since we are passing in a moment object
+  const m = addTz(date, timezone); // no parsezone since we are passing in a moment object
   if (m.minutes() === 0) { // if on the hour
     return ((format === 24) ? m.format("HH") : m.format("hA"));
   } else { // if not on the hour
@@ -363,7 +366,6 @@ module.exports = {
   readFile,
   getStringTime,
   stringDate,
-  momentDate,
   convertDate,
   sendMessageHandler,
   checkPermissions,

--- a/handlers/strings.js
+++ b/handlers/strings.js
@@ -39,7 +39,7 @@ const SETUP_MESSAGE = "\
 Hi! Lets get me setup for use in this Discord. The steps are outlined below, but for a detailed setup guide, visit http://niles.seanecoffey.com/setup \n\
 \n1. Invite `niles-291@niles-169605.iam.gserviceaccount.com` to \'Make changes to events\' under the Permission Settings on the Google Calendar you want to use with Niles\n\
 2. Enter the Calendar ID of the calendar to Discord using the `!id` command, i.e. `!id 123abc@123abc.com`\n\
-3. Enter the timezone you want to use in Discord with the `!tz` command, i.e. `!tz America/New_York` No spaces in formatting.`\n\
+3. Enter the timezone you want to use in Discord with the `!tz` command, i.e. `!tz America/New_York` No spaces in formatting.\n\
 \n Niles should now be able to sync with your Google calendar and interact with on you on Discord, try `!display` to get started!";
 
 const RESTRICT_ROLE_MESSAGE = "\
@@ -49,10 +49,24 @@ The person assigning the restriction must have the role being assigned. \n\
 i.e. Create a role called *Scheduler*, and then tell Niles to only allow people with that role using `!admin Scheduler` (case sensitive)\n\
 **Warning - Experimental Feature - Please go to the Niles discord server and post if you have any issues with this feature**";
 
+const DISPLAYOPTIONS_USAGE =
+`**displayoptions USAGE**\`\`\`
+    COMMAND                       PARAMS      EFFECT
+    ---------------------------------------------------------------------------
+    !displayoptions help          (0|1)       hide/show help
+    !displayoptions pin           (0|1)       pin calendar message
+    !displayoptions format        (12|24)     12h or 24h clock display 
+    !displayoptions tzdisplay     (0|1)       hide/show timezone
+    !displayoptions emptydays     (0|1)       hide/show empty days
+    !displayoptions trim          (n)         trim event names to n characters (0 = off)
+    \`\`\`
+    `;
+
 module.exports = {
   HELP_MESSAGE,
   NO_CALENDAR_MESSAGE,
   SETUP_MESSAGE,
   SETUP_HELP,
-  RESTRICT_ROLE_MESSAGE
+  RESTRICT_ROLE_MESSAGE,
+  DISPLAYOPTIONS_USAGE
 };


### PR DESCRIPTION
- Introduced a date<->event relation classifier (helper)
- Refactored the getEvents function -1 loop
- modified display of event times to represent multi-day timing
Also:
- add displayoption to filter out empty days
- add displayoption to limit displayed event title length to n
- cleanup displayoption usage message