### PR TITLE
Fix "12 AM end"  + Option to show/hide past events + Introduce days-selection + Inline embeds

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -50,6 +50,7 @@ Visit the [setup page](https://niles.seanecoffey.com/setup) for more detailed se
 * `!displayoptions format`    - Change clock format between 12 and 24-hour clock format, takes 12 or 24 as input i.e. `displayoptions format 24` to disply events in 24-hour clock format.
 * `!displayoptions tzdisplay` - Turn off timezone display, take 1 or 0 as input (on or off) i.e. `!displayoptions tzdisplay 0` to turn off timezone display.
 * `!displayoptions emptydays` - Hide or show empty days, takes 1 or 0 as input (show or hide) i.e. `!displayoptions emptydays 0` to hide empty days
+* `!displayoptions showpast`  - Hide or show past events of today, takes 1 or 0 as input (show or hide) i.e. `!displayoptions showpast 1` to show past events
 * `!displayoptions trim`      - Trim event names to n characters, with 0 being off. i.e. `!displayoptions trim 15` will limit event names to 5 characters and the rest being `...`
 
 ### !create formatting

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,6 +53,10 @@ Visit the [setup page](https://niles.seanecoffey.com/setup) for more detailed se
 * `!displayoptions showpast`  - Hide or show past events of today, takes 1 or 0 as input (show or hide) i.e. `!displayoptions showpast 1` to show past events
 * `!displayoptions trim`      - Trim event names to n characters, with 0 being off. i.e. `!displayoptions trim 15` will limit event names to 5 characters and the rest being `...`
 * `!displayoptions days`      - Set the number of days to display i.e. `!displayoptions days 14` will try to show 2 weeks of events (discord limits may hit! use `!displayoptions emptydays 0`)
+* `!displayoptions style`     - use old or new event display style i.e. `!displayoptions style code` will use the old code format, `displayoptions style embed` will use the new embed format
+* `!displayoptions inline`    - show event days inline (see below for examples), takes 0 or 1 as input (on or off) i.e. `!displayoptions inline 1` will make days appear inline. 
+* `!displayoptions description` - hide/show event description (only compatible with embed style )
+
 
 ### !create formatting
 `!create` is entirely handled by Google Calendar.
@@ -67,6 +71,29 @@ Multi-day events can be created with keywords " - " or " to " etc...
 e.g. `01/30/2020 - 05/30/2020`
 
 There is no way to change it and no plans to add middleware to convert it (Natural Language Processing is out of the scope of Niles)
+
+### Style
+#### Code vs Embed
+- Code supports up to 2048 characters, embed supports 6000 characters
+- Descriptions can only be shown with embed
+
+<details>
+<summary>Code and Embed examples</summary>
+<br>
+
+Code
+
+![image](https://user-images.githubusercontent.com/15132783/97769587-84649180-1b02-11eb-8ac2-cbcb2550ac32.png)
+
+Embed (Yes Inline)
+
+![image](https://user-images.githubusercontent.com/15132783/88202500-f6316300-cc16-11ea-9959-8b504efd8f68.png)
+
+Embed (Not Inline)
+
+![image](https://user-images.githubusercontent.com/15132783/88202551-0ba68d00-cc17-11ea-9a6c-cb6a44db93c7.png)
+
+</details>
 
 ## Support
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,6 +52,7 @@ Visit the [setup page](https://niles.seanecoffey.com/setup) for more detailed se
 * `!displayoptions emptydays` - Hide or show empty days, takes 1 or 0 as input (show or hide) i.e. `!displayoptions emptydays 0` to hide empty days
 * `!displayoptions showpast`  - Hide or show past events of today, takes 1 or 0 as input (show or hide) i.e. `!displayoptions showpast 1` to show past events
 * `!displayoptions trim`      - Trim event names to n characters, with 0 being off. i.e. `!displayoptions trim 15` will limit event names to 5 characters and the rest being `...`
+* `!displayoptions days`      - Set the number of days to display i.e. `!displayoptions days 14` will try to show 2 weeks of events (discord limits may hit! use `!displayoptions emptydays 0`)
 
 ### !create formatting
 `!create` is entirely handled by Google Calendar.

--- a/handlers/commands.js
+++ b/handlers/commands.js
@@ -105,9 +105,13 @@ function deleteMessages(message) {
 function createDayMap(message) {
   let dayMap = [];
   let tz = helpers.getValidTz(message.guild.id);
-  // this is automatically the start of the day in current TimeZone
+  let guildSettings = helpers.getGuildSettings(message.guild.id, "settings");
   // allowing all days to be correctly TZ adjusted
-  let d = DateTime.fromJSDate(new Date()).setZone(tz).startOf("day");
+  let d = DateTime.fromJSDate(new Date()).setZone(tz);
+  // if Option to show past events is set, start at startOf Day instead of NOW()
+  if(guildSettings.showpast === "1") {
+    d = d.startOf("day");
+  }
   dayMap[0] =  d;
   for (let i = 1; i < 7; i++) {
     dayMap[i] = d.plus({ days: i }); //DateTime is immutable, this creates new objects!
@@ -516,6 +520,18 @@ function displayOptions(message) {
       message.channel.send("Changed display of empty days to 0 (off)");
     } else {
       message.channel.send("Please only use 0 or 1 for the calendar empty days display options, (off or on)");
+    }
+  } else if (pieces[1] === "showpast") {
+    if (pieces[2] === "1") {
+      guildSettings.showpast = "1";
+      helpers.writeGuildSpecific(message.guild.id, guildSettings, "settings");
+      message.channel.send("Changed display of today's past events to 1 (on)");
+    } else if (pieces[2] === "0") {
+      guildSettings.showpast = "0";
+      helpers.writeGuildSpecific(message.guild.id, guildSettings, "settings");
+      message.channel.send("Changed display of today's past events 0 (off)");
+    } else {
+      message.channel.send("Please only use 0 or 1 for the display of today's past events option. (off or on) ");
     }
   } else if (pieces[1] === "trim") {
     if (pieces[2] !== null) {

--- a/handlers/commands.js
+++ b/handlers/commands.js
@@ -159,6 +159,7 @@ function getEvents(message, calendarID, dayMap) {
               summary: json[i].summary,
               start: json[i].start,
               end: json[i].end,
+              description: json[i].description,
               type: eType
             });
           }
@@ -197,10 +198,42 @@ function getEvents(message, calendarID, dayMap) {
 }
 
 function generateCalendar(message, dayMap) {
+  let guildSettings = helpers.getGuildSettings(message.guild.id, "settings");
+  let p = defer();
+  // create embed
+  let embed = new bot.discord.MessageEmbed();
+  embed.setTitle("CALENDAR");
+  embed.setURL("https://calendar.google.com/calendar/embed?src=" + guildSettings.calendarID);
+  embed.setColor("BLUE");
+  embed.setFooter("Last update");
+  if (guildSettings.helpmenu === "1") {
+    embed.addField("USING THIS CALENDAR", "To create events use ``!create`` or ``!scrim`` followed by your event details i.e. ``!scrim xeno on monday at 8pm-10pm``\n\nTo delete events use``!delete <day> <start time>`` i.e. ``!delete monday 5pm``\n\nHide this message using ``!displayoptions help 0``\n\nEnter ``!help`` for a full list of commands.", false);
+  }
+  if (guildSettings.tzDisplay === "1") { // display timezone
+    embed.addField("Timezone", guildSettings.timezone, false);
+  }
+  embed.setTimestamp(new Date());
+  // set description or fields
+  if (guildSettings.style === "code") {
+    embed.setDescription = generateCalendarCodeblock(message, dayMap);
+    // character check
+    //Handle Calendars Greater Than 2048 Characters Long
+    if (finalString.length>2048) {
+      message.channel.send("Your total calendar length exceeds 2048 characters - this is a Discord limitation - Try reducing the length of your event names or total number of events");
+      p.reject(2048);
+      return p.promise;
+    }
+  }
+  else if (guildSettings.style === "embed") {
+    embed.fields = generateCalendarEmbed(message, dayMap);
+  }
+  p.resolve(embed);
+  return p.promise;
+}
+
+function generateCalendarCodeblock(message, dayMap) {
   let calendar = helpers.getGuildSettings(message.guild.id, "calendar");
   let guildSettings = helpers.getGuildSettings(message.guild.id, "settings");
-  let format = guildSettings.format;
-  let p = defer();
   let finalString = "";
   for (let i = 0; i < dayMap.length; i++) {
     let key = "day" + String(i);
@@ -261,28 +294,62 @@ function generateCalendar(message, dayMap) {
       sendString += "```";
     }
     finalString += sendString;
-    //Handle Calendars Greater Than 2048 Characters Long
-    if (finalString.length>2048) {
-      message.channel.send("Your total calendar length exceeds 2048 characters - this is a Discord limitation - Try reducing the length of your event names or total number of events");
-      p.reject(2048);
-      return p.promise;
+  }
+  return finalString // return finalstring to generateCalendar
+}
+
+function generateCalendarEmbed(message, dayMap) {
+  let calendar = helpers.getGuildSettings(message.guild.id, "calendar");
+  let guildSettings = helpers.getGuildSettings(message.guild.id, "settings");
+  // start formatting
+  let fields = [];
+  for (let i = 0; i < dayMap.length; i++) {
+    let key = "day" + String(i);
+    let tempValue = "";
+    let fieldObj = {
+      name: "**" + dayMap[i].toLocaleString({ weekday: "long" }) + "** - " + dayMap[i].toLocaleString({ month: "long", day: "2-digit"}),
+      inline: (guildSettings.inline === "1")
+    };
+    if (guildSettings.emptydays === "0" && calendar[key].length === 0) {
+      continue;
     }
+    if (calendar[key].length === 0) {
+      tempValue = "\u200b";
+    } else {
+      // Map events for each day
+      for (let m = 0; m < calendar[key].length; m++) {
+        let duration = "";
+        if (Object.keys(calendar[key][m].start).includes("date")) {
+          // no need for temp start/fin dates
+          duration = "All Day"
+        } else if (Object.keys(calendar[key][m].start).includes("dateTime")) {
+          if (calendar[key][m].type === eventType.SINGLE || calendar[key][m].type === eventType.MULTISTART) {
+            tempStartDate = helpers.getStringTime(calendar[key][m].start.dateTime, message.guild.id);
+          }
+          if (calendar[key][m].type === eventType.SINGLE || calendar[key][m].type === eventType.MULTYEND) {
+            tempFinDate = helpers.getStringTime(calendar[key][m].end.dateTime, message.guild.id);
+          }
+          if (calendar[key][m].type === eventType.MULTIMID) {
+            duration = "All Day";
+          } else {
+            duration = tempStartDate + " - " + tempFinDate;
+          }
+        }
+        // construct field object with summary + description
+        let eventTitle = helpers.trimEventName(calendar[key][m].summary, guildSettings.trim);
+        let description = helpers.descriptionParser(calendar[key][m].description);
+        tempValue += `**${duration}** | ${eventTitle}\n`;
+        // if we should add description
+        if ((description !== "undefined") && (guildSettings.description === "1")) {
+          tempValue += `\`${description}\`\n`;
+        }
+      }
+    }
+    // finalize field object
+    fieldObj.value = tempValue;
+    fields.push(fieldObj);
   }
-  let embed = new bot.discord.MessageEmbed();
-  embed.setTitle("CALENDAR");
-  embed.setURL("https://calendar.google.com/calendar/embed?src=" + guildSettings.calendarID);
-  embed.setColor("BLUE");
-  embed.setDescription(finalString);
-  embed.setFooter("Last update");
-  if (guildSettings.helpmenu === "1") {
-    embed.addField("USING THIS CALENDAR", "To create events use ``!create`` or ``!scrim`` followed by your event details i.e. ``!scrim xeno on monday at 8pm-10pm``\n\nTo delete events use``!delete <day> <start time>`` i.e. ``!delete monday 5pm``\n\nHide this message using ``!displayoptions help 0``\n\nEnter ``!help`` for a full list of commands.", false);
-  }
-  if (guildSettings.tzDisplay === "1") { // display timezone
-    embed.addField("Timezone", guildSettings.timezone, false);
-  }
-  embed.setTimestamp(new Date());
-  p.resolve(embed);
-  return p.promise;
+  return fields; // return field array 
 }
 
 function startUpdateTimer(message) {
@@ -558,8 +625,51 @@ function displayOptions(message) {
       guildSettings.days = size;
       helpers.writeGuildSpecific(message.guild.id, guildSettings, "settings");
       message.channel.send("Changed days to display to: "+size + " (you may have to use `!displayoptions emptydays 0`)");
-    } else  {
+    } else {
       message.channel.send("Please provide a number of days to display. (7 = default, 90 = max)");
+    }
+  } else if (pieces[1] === "style") {
+    if (pieces[2] === "code") {
+      guildSettings.style = "code";
+      // revert dependent options
+      guildSettings.inline = "0";
+      guildSettings.description = "0";
+      helpers.writeGuildSpecific(message.guild.id, guildSettings, "settings");
+      message.channel.send("Changed display style to `code`");
+    } else if (pieces[2] === "embed") {
+      guildSettings.style = "embed";
+      helpers.writeGuildSpecific(message.guild.id, guildSettings, "settings");
+      message.channel.send("Changed display style to `embed`");
+    } else {
+      message.channel.send("Please only use code or embed for the style choice. (see niles.seanecoffey.com#style)");
+    }
+  } else if (pieces[1] === "inline") {
+    if (guildSettings.style === "code") {
+      message.channel.send("This displayoption is only compatible with the `embed` display style") 
+    } else if (pieces[2] === "1") {
+      guildSettings.inline = "1";
+      helpers.writeGuildSpecific(message.guild.id, guildSettings, "settings");
+      message.channel.send("Changed inline events to 1 (on)");
+    } else if (pieces[2] === "0") {
+      guildSettings.inline = "0";
+      helpers.writeGuildSpecific(message.guild.id, guildSettings, "settings");
+      message.channel.send("Changed inline events to 0 (off)");
+    } else {
+      message.channel.send("Please only use 0 or 1 for inline events. (off or on) - see niles.seanecoffey.com#style");
+    }
+  } else if (pieces[1] === "description") {
+    if (guildSettings.style === "code") {
+      message.channel.send("This displayoption is only compatible with the `embed` display style") 
+    } else if (pieces[2] === "1") {
+      guildSettings.description = "1";
+      helpers.writeGuildSpecific(message.guild.id, guildSettings, "settings");
+      message.channel.send("Changed display of descriptions to 1 (on)");
+    } else if (pieces[2] === "0") {
+      guildSettings.description = "0";
+      helpers.writeGuildSpecific(message.guild.id, guildSettings, "settings");
+      message.channel.send("Changed display of descriptions to 0 (off)");
+    } else {
+      message.channel.send("Please only use 0 or 1 for the display of descriptions (off or on)");
     }
   } else {
     message.channel.send(strings.DISPLAYOPTIONS_USAGE);
@@ -598,11 +708,11 @@ function listSingleEventsWithinDateRange(message, calendarId, dayMap) {
 			for (let i = 0; i < json.length; i++) {
 				let event = {
 					id: json[i].id,
-					summary: json[i].summary,
+          summary: json[i].summary,
 					location: json[i].location,
 					start: json[i].start,
 					end: json[i].end,
-					status: json[i].status
+          status: json[i].status
 				};
 				eventsArray.push(event);
 			}

--- a/handlers/guilds.js
+++ b/handlers/guilds.js
@@ -29,6 +29,7 @@ exports.create = (guild) => {
     "tzDisplay": "0",
     "allowedRoles": [],
     "emptydays": "1",
+    "showpast": "0",
     "trim": 0
   };
   const guildData = {

--- a/handlers/guilds.js
+++ b/handlers/guilds.js
@@ -19,19 +19,7 @@ exports.create = (guild) => {
     "lastUpdate": "",
     "calendarMessageId": ""
   };
-  let defaultSettings = {
-    "prefix": "!",
-    "calendarID": "",
-    "calendarChannel": "",
-    "timezone": "",
-    "helpmenu": "1",
-    "format": 12,
-    "tzDisplay": "0",
-    "allowedRoles": [],
-    "emptydays": "1",
-    "showpast": "0",
-    "trim": 0
-  };
+
   const guildData = {
     "guildid": guild.id,
     "name": guild.name,
@@ -45,7 +33,7 @@ exports.create = (guild) => {
   } else if (!fs.existsSync(guildPath)) { // create directory and new files
     fs.mkdirSync(guildPath); 
     helpers.writeGuildSpecific(guild.id, emptyCal, "calendar");
-    helpers.writeGuildSpecific(guild.id, defaultSettings, "settings");
+    helpers.writeGuildSpecific(guild.id, helpers.defaultSettings, "settings");
     helpers.amendGuildDatabase({ [guild.id]: guildData });
     helpers.log(`Guild ${guild.id} has been created`);
     //guild.defaultChannel.send("Hi, I'm **" + bot.client.user.username + "**, I can help you sync Google Calendars with Discord! Try ``!setup`` for details on how to get started.  **NOTE**: Make sure I have the right permissions in the channel you try and use me in!");

--- a/handlers/helpers.js
+++ b/handlers/helpers.js
@@ -9,6 +9,21 @@ const eventType = {
   MULTIMID: "mm",
   MULTYEND: "me"
 };
+const defaultSettings = {
+  "prefix": "!",
+  "calendarID": "",
+  "calendarChannel": "",
+  "timezone": "",
+  "helpmenu": "1",
+  "format": 12,
+  "tzDisplay": "0",
+  "allowedRoles": [],
+  "emptydays": "1",
+  "showpast": "0",
+  "trim": 0,
+  "days": 7
+};
+
 let settings = require("../settings.js");
 let bot = require("../bot.js");
 let minimumPermissions = settings.secrets.minimumPermissions;
@@ -21,7 +36,10 @@ function getGuildSettings(id, file) {
     filePath = path.join(__dirname, "..", "stores", id, "settings.json");
   }
   // read file
-  return readFile(filePath);
+  let storedData = readFile(filePath);
+  //merge defaults and stored settings to guarantee valid data
+  let combinedData = {...defaultSettings, ...storedData };
+  return combinedData
 }
 
 function getSettings() {
@@ -367,5 +385,6 @@ module.exports = {
   yesThenCollector,
   classifyEventMatch,
   eventType,
+  defaultSettings,
   trimEventName
 };

--- a/handlers/helpers.js
+++ b/handlers/helpers.js
@@ -297,10 +297,22 @@ function classifyEventMatch(checkDate, eventStartDate, eventEndDate) {
   // multi-day event
   else if(!eventStartDate.hasSame(eventEndDate, "day"))
   {
-    if(checkDate.hasSame(eventStartDate, "day")){
+    // special case, Event ends as 12 AM spot on
+    if(checkDate.hasSame(eventStartDate, "day") && eventEndDate.diff(eventStartDate.endOf("day"),"minutes") <= 1){
+      eventMatchType = eventType.SINGLE;
+    }
+    // this removes the entry for the next day of a 12AM ending event
+    else if (eventEndDate.diff(checkDate.startOf("day"),"minutes") <= 1){
+      let eventMatchType = eventType.NOMATCH;
+    }
+    else if(checkDate.hasSame(eventStartDate, "day")){
       eventMatchType = eventType.MULTISTART;
     }
     else if(checkDate.hasSame(eventEndDate, "day")){
+      eventMatchType = eventType.MULTYEND;
+    } 
+    // this makes the 12AM ending multi-day events show as ""..... - 12:00 AM"
+    else if(checkDate.startOf("day") > eventStartDate.startOf("day") && checkDate.startOf("day") < eventEndDate.startOf("day") && eventEndDate.diff(checkDate.endOf("day"),"minutes") <= 1){
       eventMatchType = eventType.MULTYEND;
     } 
     else if(checkDate.startOf("day") > eventStartDate.startOf("day") && checkDate.startOf("day") < eventEndDate.startOf("day")){

--- a/handlers/helpers.js
+++ b/handlers/helpers.js
@@ -1,6 +1,7 @@
 const fs = require("fs");
 const path = require("path");
 const defer = require("promise-defer");
+const stripHtml = require("string-strip-html");
 const { DateTime, IANAZone, FixedOffsetZone } = require("luxon");
 const eventType = {
   NOMATCH: "nm",
@@ -21,7 +22,10 @@ const defaultSettings = {
   "emptydays": "1",
   "showpast": "0",
   "trim": 0,
-  "days": 7
+  "days": 7,
+  "style": "code",
+  "inline": "0",
+  "description": "0"
 };
 
 let settings = require("../settings.js");
@@ -358,6 +362,16 @@ function trimEventName(eventName, trimLength){
   return eventName;
 }
 
+/**
+ * this helper function strips all html formatting from the description.
+ * @param {string} inputString - the unclean string
+ * @return {string} strippedString - string stripped of html
+ */
+function descriptionParser(inputString) {
+  const decoded = decodeURI(inputString); // decode URI
+  const replaced = decoded.replace(/(<br>)+/g, "\n"); // replace <br> with \n
+  return stripHtml(replaced); // strip html
+}
 
 module.exports = {
   fullname,
@@ -386,5 +400,6 @@ module.exports = {
   classifyEventMatch,
   eventType,
   defaultSettings,
-  trimEventName
+  trimEventName,
+  descriptionParser
 };

--- a/handlers/strings.js
+++ b/handlers/strings.js
@@ -59,6 +59,7 @@ const DISPLAYOPTIONS_USAGE =
     !displayoptions emptydays  (0|1)    hide/show empty days
     !displayoptions showpast   (0|1)    hide/show today's past events
     !displayoptions trim       (n)      trim event names to n characters (0 = off)
+    !displayoptions days       (n)      number of days to display (max 90)
     \`\`\`
     `;
 

--- a/handlers/strings.js
+++ b/handlers/strings.js
@@ -51,15 +51,18 @@ i.e. Create a role called *Scheduler*, and then tell Niles to only allow people 
 
 const DISPLAYOPTIONS_USAGE =
 `**displayoptions USAGE**\`\`\`
-    COMMAND                    PARAMS   EFFECT
-    !displayoptions help       (0|1)    hide/show help
-    !displayoptions pin        (0|1)    pin calendar message
-    !displayoptions format     (12|24)  12h or 24h clock display 
-    !displayoptions tzdisplay  (0|1)    hide/show timezone
-    !displayoptions emptydays  (0|1)    hide/show empty days
-    !displayoptions showpast   (0|1)    hide/show today's past events
-    !displayoptions trim       (n)      trim event names to n characters (0 = off)
-    !displayoptions days       (n)      number of days to display (max 90)
+    COMMAND                      PARAMS        EFFECT
+    !displayoptions help         (0|1)         hide/show help
+    !displayoptions pin          (0|1)         pin calendar message
+    !displayoptions format       (12|24)       12h or 24h clock display 
+    !displayoptions tzdisplay    (0|1)         hide/show timezone
+    !displayoptions emptydays    (0|1)         hide/show empty days
+    !displayoptions showpast     (0|1)         hide/show today's past events
+    !displayoptions trim         (n)           trim event names to n characters (0 = off)
+    !displayoptions days         (n)           number of days to display (max 90)
+    !displayoptions style        (code|embed)  use old or new event display style (see niles.seanecoffey.com#style)
+    !displayoptions inline       (0|1)         makes embed display inline (see niles.seanecoffey.com#style)
+    !displayoptions description  (0|1)         hide/show event description (only compatible with embed)
     \`\`\`
     `;
 

--- a/handlers/strings.js
+++ b/handlers/strings.js
@@ -51,14 +51,14 @@ i.e. Create a role called *Scheduler*, and then tell Niles to only allow people 
 
 const DISPLAYOPTIONS_USAGE =
 `**displayoptions USAGE**\`\`\`
-    COMMAND                       PARAMS      EFFECT
-    ---------------------------------------------------------------------------
-    !displayoptions help          (0|1)       hide/show help
-    !displayoptions pin           (0|1)       pin calendar message
-    !displayoptions format        (12|24)     12h or 24h clock display 
-    !displayoptions tzdisplay     (0|1)       hide/show timezone
-    !displayoptions emptydays     (0|1)       hide/show empty days
-    !displayoptions trim          (n)         trim event names to n characters (0 = off)
+    COMMAND                    PARAMS   EFFECT
+    !displayoptions help       (0|1)    hide/show help
+    !displayoptions pin        (0|1)    pin calendar message
+    !displayoptions format     (12|24)  12h or 24h clock display 
+    !displayoptions tzdisplay  (0|1)    hide/show timezone
+    !displayoptions emptydays  (0|1)    hide/show empty days
+    !displayoptions showpast   (0|1)    hide/show today's past events
+    !displayoptions trim       (n)      trim event names to n characters (0 = off)
     \`\`\`
     `;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -186,6 +186,11 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "ent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
+      "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0="
+    },
     "event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -313,6 +318,26 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.trim": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/lodash.trim/-/lodash.trim-4.5.1.tgz",
+      "integrity": "sha1-NkJefukL5KpeJ7zruFt9EepHqlc="
+    },
+    "lodash.without": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
+      "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw="
+    },
     "luxon": {
       "version": "1.25.0",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.25.0.tgz",
@@ -375,6 +400,37 @@
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+    },
+    "ranges-apply": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/ranges-apply/-/ranges-apply-3.2.3.tgz",
+      "integrity": "sha512-lc5jJU3ecZZyY3oifVziIR40rzbK7lTHn+l5iAKTg0yQdR43wj5UtpVqW57Zt3eWSuQI6wqa2RNhdk5FNCPZOA==",
+      "requires": {
+        "ranges-merge": "^5.0.3"
+      }
+    },
+    "ranges-merge": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/ranges-merge/-/ranges-merge-5.0.3.tgz",
+      "integrity": "sha512-UPV4IZVpySzOK8MVfPY8VhMPpT/WKG2V/9HCar3e4zM7h97ml2BKKfkdCcR2PgqGEUDLJr25dElKDo94/5tIMw==",
+      "requires": {
+        "ranges-sort": "^3.13.3"
+      }
+    },
+    "ranges-push": {
+      "version": "3.7.22",
+      "resolved": "https://registry.npmjs.org/ranges-push/-/ranges-push-3.7.22.tgz",
+      "integrity": "sha512-stqx+AKzEl/62QdbGhn6pKO5dWFf5H5xT59y14KrruUn+QW2M6skq5jsJ3RdpKpmYVDfjGnOiQGL12bzb7xcPw==",
+      "requires": {
+        "ranges-merge": "^5.0.3",
+        "string-collapse-leading-whitespace": "^3.0.2",
+        "string-trim-spaces-only": "^2.8.23"
+      }
+    },
+    "ranges-sort": {
+      "version": "3.13.3",
+      "resolved": "https://registry.npmjs.org/ranges-sort/-/ranges-sort-3.13.3.tgz",
+      "integrity": "sha512-5S9d5SHb3/phG3EaniXqR9hJiN5EnQjityNRktq3XIxt0TDnouB8glWb61QANZFYdGQ70A5YUNQ8eX/Jmlw6nQ=="
     },
     "request": {
       "version": "2.88.2",
@@ -457,6 +513,39 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+    },
+    "string-collapse-leading-whitespace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/string-collapse-leading-whitespace/-/string-collapse-leading-whitespace-3.0.2.tgz",
+      "integrity": "sha512-1+cuXaqe4d9ut/evICLjHcg5AAWwLKu3mMRhSBrhb4Z+lzAWN8sVspHraZad8FrBc8XJ3bzsjknSN5aMCO4tkg=="
+    },
+    "string-left-right": {
+      "version": "2.3.31",
+      "resolved": "https://registry.npmjs.org/string-left-right/-/string-left-right-2.3.31.tgz",
+      "integrity": "sha512-xsMj1WXOpqPEwPC1pVULyXXZuegyx0f4H07L7QafkyC+S60c2D7h8ANb3qoywaQ9exJYqA1l6wz0Q1oTsbXs9Q==",
+      "requires": {
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.isplainobject": "^4.0.6"
+      }
+    },
+    "string-strip-html": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/string-strip-html/-/string-strip-html-6.2.0.tgz",
+      "integrity": "sha512-mrHv7UWYEq3OtE7YxB1SIpCnbM0iCuMX9drYtLJW5rvjzLVd+BrmtXVhvw898m1u8+cdJscDLNy0aVo6U5NAMQ==",
+      "requires": {
+        "ent": "^2.2.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.trim": "^4.5.1",
+        "lodash.without": "^4.4.0",
+        "ranges-apply": "^3.2.3",
+        "ranges-push": "^3.7.22",
+        "string-left-right": "^2.3.31"
+      }
+    },
+    "string-trim-spaces-only": {
+      "version": "2.8.23",
+      "resolved": "https://registry.npmjs.org/string-trim-spaces-only/-/string-trim-spaces-only-2.8.23.tgz",
+      "integrity": "sha512-MQAksLUGqogkq8qjDBjsASojgEZUZKU2S+cYvH0u9yXrJUWUih9YuNfFK0RtIxSiRvS/dPg9V44dR8GO4nEn5w=="
     },
     "strip-ansi": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "niles",
-  "version": "2.1.1",
+  "version": "2.2.1",
   "description": "niles discord bot",
   "main": "index.js",
   "scripts": {
@@ -13,7 +13,8 @@
     "discord.js": "^12.3.1",
     "luxon": "^1.25.0",
     "@mchangrh/node-google-calendar": "^2.0.3",
-    "promise-defer": "^1.0.0"
+    "promise-defer": "^1.0.0",
+    "string-strip-html": "^6.2.0"
   },
   "devDependencies": {},
   "repository": {


### PR DESCRIPTION
- Fix "12 AM end" events display in next day
- this will make 1day events that end exactly 12 AM end in the start day
- multi-day events will end in last full day
- Added Option to show/hide past events of today 
- !displayoptions showpast 1/0 toggles the effect
- Default restored to old "hide past" behavior
- Documentation updated
- Introduce Day-selection & safer defaults
- introduce !displayoptions days n to change # of days to show
- move defaultSettings from guild to helpers and merge with stored
- maximum # of days fixed to 90 as cautionary measure